### PR TITLE
HAS + SIZE + USE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@
 *.swo
 *.pyc
 queued
+pkg
+bin
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "src/github.com/timtadh/getopt"]
 	path = src/github.com/timtadh/getopt
 	url = https://github.com/timtadh/getopt.git
+[submodule "src/github.com/timtadh/data-structures"]
+	path = src/github.com/timtadh/data-structures
+	url = https://github.com/timtadh/data-structures

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ and deque data. The client has the following verbs
 - DEQUE
 - HAS
 - SIZE
+- USE
 
 the server can send the following reponse status words
 
@@ -67,6 +68,16 @@ reponse it is ASCII.
 
 The client can send any command at any time. The server may at any command
 respond with ERROR if there was a problem processing the command.
+
+##### USE name
+
+Use the named queue. You never have to issue this command. If you do not
+you will automatically be using a queue named "default". If the queue does
+not this command will create one. The server should respond:
+
+     OK
+
+name should have no spaces and should be utf8.
 
 ##### ENQUE XXXXXXXXXXXXXXXX
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Install
 
     go get github.com/timtadh/queued
 
-### Command Docs
+### Usage Docs
 
 ```
 queued <port>
@@ -36,4 +36,92 @@ Options
 On `godoc.org`:
 
 [Documentation](http://godoc.org/github.com/timtadh/queued)
+
+### Protocol
+
+
+This package implements a TCP network service which allows clients to queue
+and deque data. The client has the following verbs
+
+- ENQUE
+- DEQUE
+- HAS
+- SIZE
+
+the server can send the following reponse status words
+
+- OK
+- ERROR
+- ITEM
+- TRUE
+- FALSE
+- SIZE
+
+All messages have the following format:
+
+    COMMAND DATA
+
+COMMAND is a single ASCII word with no spaces. DATA is the rest of the line.
+DATA is optional. For ERROR, ENQUE and ITEM it is Base64 encoded. For SIZE
+reponse it is ASCII.
+
+The client can send any command at any time. The server may at any command
+respond with ERROR if there was a problem processing the command.
+
+##### ENQUE XXXXXXXXXXXXXXXX
+
+XXXXXXXXXXXXXXXXXX should be base64 encoded data. If it is not the
+server will respond with and ERROR.  Otherwise the server will repond
+
+    OK
+
+The server should always respond with OK if the command is properly
+formated. If it does not that means there is an internal error in the
+server.
+
+##### DEQUE
+
+If the queue is empty the server will respond with:
+
+    ERROR cXVldWUgaXMgZW1wdHk=
+
+Which decodes too:
+
+    ERROR queue is empty
+
+Otherwise it repondes with
+
+    ITEM XXXXXXXXXXXXXXX
+
+##### HAS XXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+HAS checks for the existence of an item. It doesn't send the item but
+rather the base64 encoded sha265sum. Example for producing this (in
+Python for simplicity)
+
+    >>> import hashlib
+    >>> hashlib.sha256('item').digest().encode('base64').strip()
+    'SjPqzV+mXysuKHHNExKGtTxBWxMWZtcRc7tuP+WTYbM='
+
+The client would send
+
+    HAS SjPqzV+mXysuKHHNExKGtTxBWxMWZtcRc7tuP+WTYbM=
+
+The server would reponse either
+
+    TRUE
+
+or
+
+    FALSE
+
+
+##### SIZE
+
+The server response with the size of the queue encoded as a base10
+ascii number. eg.
+
+    SIZE 9231
+
+For a queue that is 9,231 items long.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ starts a queued daemon, a simple queue exposed on the network.
 
 Options
     -h, --help                          print this message
+    --allow-dups                        allow duplicate items in the queue
 
     Specs
         <port>

--- a/clients/python/queued/client.py
+++ b/clients/python/queued/client.py
@@ -33,9 +33,15 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 '''
 
-
-import sys, os, socket, threading, time
+import sys
+import os
+import socket
+import threading
+import time
+import hashlib
+import binascii
 from collections import deque
+
 
 class Queue(object):
 
@@ -77,6 +83,55 @@ class Queue(object):
             if from_read:
                 print >>sys.stderr, "read thread closed it"
 
+    def size(self):
+        with self.queue_lock:
+            msg = "SIZE\n"
+            self.conn.send(msg)
+            return self.get_size_response()
+
+    def get_size_response(self):
+        cmd, data = self.get_line()
+        if cmd == "ERROR":
+            data = data.decode('base64')
+            raise Exception(data)
+        elif cmd != "SIZE":
+            raise Exception, "bad command recieved %s" % cmd
+        else:
+            return int(data)
+
+    def hash(self, data):
+        return hashlib.sha256(data).digest().encode('base64').strip()
+
+    def has_hash(self, hash):
+        try:
+            hash.decode('base64')
+        except binascii.Error, e:
+            raise Exception("Hash must be base64 encoded. Use the hash function")
+        h = hash.strip()
+        with self.queue_lock:
+            msg = "HAS " + h + "\n"
+            self.conn.send(msg)
+            return self.get_has_response()
+
+    def has(self, data):
+        h = self.hash(data)
+        with self.queue_lock:
+            msg = "HAS " + h + "\n"
+            self.conn.send(msg)
+            return self.get_has_response()
+
+    def get_has_response(self):
+        cmd, data = self.get_line()
+        if cmd == "ERROR":
+            data = data.decode('base64')
+            raise Exception(data)
+        elif cmd == "TRUE":
+            return True
+        elif cmd == "FALSE":
+            return False
+        else:
+            raise Exception("bad server response %s %s" % (cmd, data))
+
     def enque(self, data):
         with self.queue_lock:
             msg = "ENQUE " + data.encode('base64').replace('\n', '') + '\n'
@@ -86,6 +141,7 @@ class Queue(object):
     def get_enque_response(self):
         cmd, data = self.get_line()
         if cmd == "ERROR":
+            data = data.decode('base64')
             raise Exception(data)
         elif cmd != "OK":
             raise Exception, "bad command recieved %s" % cmd
@@ -98,12 +154,14 @@ class Queue(object):
     def get_deque_response(self):
         cmd, data = self.get_line()
         if cmd == "ERROR":
+            data = data.decode('base64')
             if data == "queue is empty":
                 raise IndexError(data)
             raise Exception(data)
         elif cmd != "ITEM":
             raise Exception, "bad command recieved %s" % cmd
         assert cmd == "ITEM"
+        data = data.decode('base64')
         return data
 
     def listen(self):
@@ -142,7 +200,7 @@ class Queue(object):
         command = split[0]
         rest = None
         if len(split) > 1:
-            rest = split[1].decode('base64')
+            rest = split[1].strip()
 
         return command, rest
 
@@ -153,7 +211,7 @@ def _loop(queue):
         except:
             break
         split = line.split(' ', 1)
-        command = split[0]
+        command = split[0].lower().strip()
         data = None
         if len(split) > 1:
             data = split[1]
@@ -161,11 +219,21 @@ def _loop(queue):
             queue.enque(data)
         elif command == 'enque' and data is None:
             print >>sys.stderr, "bad input, need data"
+        elif command == "has" and data is not None:
+            print queue.has(data)
+        elif command == 'has' and data is None:
+            print >>sys.stderr, "bad input, need data"
+        elif command == "size":
+            print queue.size()
         elif command == "deque":
             try:
                 print queue.deque()
             except IndexError:
                 print "queue is empty"
+        elif command == '':
+            pass
+        else:
+            print >>sys.stderr, "bad command"
 
 def main():
     queue = Queue('localhost', 9001)

--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -13,7 +13,7 @@ except ImportError:
     setuptools_kwargs = {}
 
 setup(name='queued',
-      version=0.1,
+      version=1.1,
       description=(
         'A client for queued'
       ),

--- a/clients/scala/build.sbt
+++ b/clients/scala/build.sbt
@@ -1,6 +1,6 @@
 name := "queued_client"
 
-version := "0.01"
+version := "1.1"
 
 scalaVersion := "2.10.2"
 

--- a/clients/scala/src/main/scala/edu/cwru/selab/queued/client.scala
+++ b/clients/scala/src/main/scala/edu/cwru/selab/queued/client.scala
@@ -94,6 +94,21 @@ class Queued(host:String, port:Int) {
     return new Pair[String, String](command, rest)
   }
 
+  def use(name:String) {
+    send("USE " + name + "\n")
+    check_use_response()
+  }
+
+  def check_use_response() {
+    val line = get_line()
+    if (line._1 == "ERROR") {
+      val err = new String(Base64.decodeBase64(line._2.getBytes()));
+      throw new Exception(err)
+    } else if (line._1 != "OK") {
+      throw new Exception("Bad command recieved")
+    }
+  }
+
   def enque(data:String) {
     send("ENQUE " + new String(Base64.encodeBase64(data.getBytes())) + "\n")
     check_enque_response()
@@ -178,6 +193,9 @@ object MainQueued {
       queue.enque("asdf")
       queue.enque("asf")
       queue.enque("assdf")
+      queue.use("wizard")
+      println(queue.size())
+      queue.use("default")
       println(queue.size())
       println(queue.has("asdf"))
       println(queue.has("asf"))

--- a/clients/scala/src/main/scala/edu/cwru/selab/queued/client.scala
+++ b/clients/scala/src/main/scala/edu/cwru/selab/queued/client.scala
@@ -31,11 +31,15 @@
  */
 package edu.cwru.selab.queued;
 
+import scala.io.Source;
+
 import java.net.Socket;
 import java.io;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.security.MessageDigest;
+
 import org.apache.commons.codec.binary.Base64;
-import scala.io.Source;
+
 
 class Queued(host:String, port:Int) {
 
@@ -85,7 +89,7 @@ class Queued(host:String, port:Int) {
     val command = split(0)
     var rest = ""
     if (split.length > 1) {
-      rest = new String(Base64.decodeBase64(split(1).getBytes()));
+      rest = split(1)
     }
     return new Pair[String, String](command, rest)
   }
@@ -98,7 +102,8 @@ class Queued(host:String, port:Int) {
   def check_enque_response() {
     val line = get_line()
     if (line._1 == "ERROR") {
-      throw new Exception(line._2)
+      val err = new String(Base64.decodeBase64(line._2.getBytes()));
+      throw new Exception(err)
     } else if (line._1 != "OK") {
       throw new Exception("Bad command recieved")
     }
@@ -112,28 +117,79 @@ class Queued(host:String, port:Int) {
   def get_deque_response():String = {
     val line = get_line()
     if (line._1 == "ERROR") {
-      if (line._2 == "queue is empty") {
+      val err = new String(Base64.decodeBase64(line._2.getBytes()));
+      if (err == "queue is empty") {
         throw new java.lang.IndexOutOfBoundsException("queue is empty")
       }
-      throw new Exception(line._2)
+      throw new Exception(err)
     } else if (line._1 != "ITEM") {
       throw new Exception("Bad command recieved")
     }
-    return line._2
+    val data = new String(Base64.decodeBase64(line._2.getBytes()));
+    return data
   }
 
+  def hash(data:String):String = {
+    val h = MessageDigest.getInstance("SHA-256")
+    val d = h.digest(data.getBytes())
+    return new String(Base64.encodeBase64(d))
+  }
+
+  def has(data:String):Boolean = {
+    send("HAS " + hash(data) + "\n")
+    get_has_response()
+  }
+
+  def get_has_response():Boolean = {
+    val line = get_line()
+    if (line._1 == "ERROR") {
+      val err = new String(Base64.decodeBase64(line._2.getBytes()));
+      throw new Exception(err)
+    } else if (line._1 == "TRUE") {
+      return true
+    } else if (line._1 == "FALSE") {
+      return false
+    }
+    throw new Exception("Bad command recieved")
+  }
+
+  def size():Int = {
+    send("SIZE" + "\n")
+    get_size_response()
+  }
+
+  def get_size_response():Int = {
+    val line = get_line()
+    if (line._1 == "ERROR") {
+      val err = new String(Base64.decodeBase64(line._2.getBytes()));
+      throw new Exception(err)
+    } else if (line._1 != "SIZE") {
+      throw new Exception("Bad command recieved")
+    }
+    line._2.toInt
+  }
 }
 
 object MainQueued {
   def main(args: Array[String]) {
     val queue = new Queued("localhost", 9001)
     try {
+      println(queue.size())
       queue.enque("asdf")
-      queue.enque("asdf")
-      queue.enque("asdf")
+      queue.enque("asf")
+      queue.enque("assdf")
+      println(queue.size())
+      println(queue.has("asdf"))
+      println(queue.has("asf"))
+      println(queue.has("assdf"))
       println(queue.deque())
       println(queue.deque())
+      println(queue.size())
       println(queue.deque())
+      println(queue.size())
+      println(queue.has("asdf"))
+      println(queue.has("asf"))
+      println(queue.has("assdf"))
       println(queue.deque())
     } catch {
       case e:java.lang.IndexOutOfBoundsException => println("queue empty")

--- a/main.go
+++ b/main.go
@@ -67,8 +67,7 @@ Options
     -h, --help                          print this message
 
 Specs
-    <port>
-        A bindable port number.
+    <port>  A bindable port number.
 `
 
 func Usage(code int) {
@@ -92,18 +91,25 @@ func parse_int(str string) int {
 }
 
 func main() {
-
-	args, optargs, err := getopt.GetOpt(os.Args[1:], "h", []string{"help"})
+	short := "h"
+	long := []string{
+		"help",
+		"allow-dups",
+	}
+	args, optargs, err := getopt.GetOpt(os.Args[1:], short, long)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		Usage(ErrorCodes["opts"])
 	}
 
 	port := -1
+	dups := false
 	for _, oa := range optargs {
 		switch oa.Opt() {
 		case "-h", "--help":
 			Usage(0)
+		case "--allow-dups":
+			dups = true
 		}
 	}
 
@@ -114,6 +120,7 @@ func main() {
 	port = parse_int(args[0])
 
 	fmt.Println("starting")
-	server := qnet.NewServer(queue.NewQueue())
+	server := qnet.NewServer(queue.NewQueue(dups))
 	server.Start(port)
 }
+

--- a/main.go
+++ b/main.go
@@ -65,6 +65,7 @@ starts a queued daemon, a simple queue exposed on the network.
 
 Options
     -h, --help                          print this message
+    --allow-dups                        allow duplicate items in the queue
 
 Specs
     <port>  A bindable port number.

--- a/main.go
+++ b/main.go
@@ -48,8 +48,8 @@ import (
 )
 
 import (
-	qnet "github.com/timtadh/queued/net"
-	queue "github.com/timtadh/queued/queue"
+	"github.com/timtadh/queued/net"
+	"github.com/timtadh/queued/queue"
 )
 
 var ErrorCodes map[string]int = map[string]int{
@@ -65,7 +65,8 @@ starts a queued daemon, a simple queue exposed on the network.
 
 Options
     -h, --help                          print this message
-    --allow-dups                        allow duplicate items in the queue
+    --allow-dups                        allow duplicate items in the queue.
+                                        This setting effects every queue
 
 Specs
     <port>  A bindable port number.
@@ -121,7 +122,7 @@ func main() {
 	port = parse_int(args[0])
 
 	fmt.Println("starting")
-	server := qnet.NewServer(queue.NewQueue(dups))
+	server := net.NewServer(func() net.Queue { return queue.NewQueue(dups) })
 	server.Start(port)
 }
 

--- a/net/net.go
+++ b/net/net.go
@@ -1,39 +1,90 @@
-/*
-This package implements a TCP network service which allows clients to queue and
-deque data. The client has 2 verbs "ENQUE" and "DEQUE" and the server can send 3
-reponse status words "OK", "ERROR" and "ITEM".
-
-All messages have the following format:
-
-    COMMAND DATA
-
-Where DATA is Base64 encoded and COMMAND is a single ASCII word with no spaces.
-
-The client can send ENQUE or DEQUE at any time. If the queue is empty the server
-will respond with:
-
-    ERROR cXVldWUgaXMgZW1wdHk=
-
-Which decodes too:
-
-    ERROR queue is empty
-
-Otherwise it repondes with
-
-    ITEM XXXXXXXXXXXXXXX
-
-When enqueing data the client sends
-
-    ENQUE XXXXXXXXXXXXXXXXX
-
-The server will respond with
-
-    OK
-
-Unless there is some internal error.
-
-*/
-
+// This package implements a TCP network service which allows clients to queue
+// and deque data. The client has the following verbs
+//
+//  - ENQUE
+//  - DEQUE
+//  - HAS
+//  - SIZE
+//
+// the server can send the following reponse status words
+//
+//  - OK
+//  - ERROR
+//  - ITEM
+//  - TRUE
+//  - FALSE
+//  - SIZE
+//
+// All messages have the following format:
+//
+//     COMMAND DATA
+//
+// COMMAND is a single ASCII word with no spaces. DATA is the rest of the line.
+// DATA is optional. For ERROR, ENQUE and ITEM it is Base64 encoded. For SIZE
+// reponse it is ASCII.
+//
+// The client can send any command at any time. The server may at any command
+// respond with ERROR if there was a problem processing the command.
+//
+// ENQUE XXXXXXXXXXXXXXXX
+//
+//     XXXXXXXXXXXXXXXXXX should be base64 encoded data. If it is not the server
+//     will respond with and ERROR.
+//
+//     Otherwise the server will repond
+//
+//          OK
+//
+//     The server should always respond with OK if the command is properly
+//     formated. If it does not that means there is an internal error in the
+//     server.
+//
+// DEQUE
+//
+//     If the queue is empty the server will respond with:
+//
+//         ERROR cXVldWUgaXMgZW1wdHk=
+//
+//     Which decodes too:
+//
+//         ERROR queue is empty
+//
+//     Otherwise it repondes with
+//
+//         ITEM XXXXXXXXXXXXXXX
+//
+// HAS XXXXXXXXXXXXXXXXXXXXXXXXXXX
+//
+//      HAS checks for the existence of an item. It doesn't send the item but
+//      rather the base64 encoded sha265sum. Example for producing this (in
+//      Python for simplicity)
+//
+//         >>> import hashlib
+//         >>> hashlib.sha256('item').digest().encode('base64').strip()
+//         'SjPqzV+mXysuKHHNExKGtTxBWxMWZtcRc7tuP+WTYbM='
+//
+//      The client would send
+//
+//          HAS SjPqzV+mXysuKHHNExKGtTxBWxMWZtcRc7tuP+WTYbM=
+//
+//      The server would reponse either
+//
+//          TRUE
+//
+//      or
+//
+//          FALSE
+//
+//
+// SIZE
+//
+//      The server response with the size of the queue encoded as a base10 ascii
+//      number. eg.
+//
+//          SIZE 9231
+//
+//      For a queue that is 9,231 items long.
+//
 package net
 
 /* queued

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -114,7 +114,7 @@ func sender_to_reciever(recv <-chan []byte) <-chan byte {
 }
 
 func TestConnection(t *testing.T) {
-	server := &Server{queue: queue.NewQueue(true)}
+	server := NewServer(func() Queue { return queue.NewQueue(true) })
 	connect := func() (chan<- []byte, <-chan []byte) {
 		send := make(chan []byte)
 		r := sender_to_reciever(send)
@@ -180,7 +180,7 @@ func TestConnection(t *testing.T) {
 }
 
 func TestMultiConnection(t *testing.T) {
-	server := &Server{queue: queue.NewQueue(true)}
+	server := NewServer(func() Queue { return queue.NewQueue(true) })
 	connect := func() (chan<- []byte, <-chan []byte) {
 		send := make(chan []byte)
 		r := sender_to_reciever(send)

--- a/net/queue.go
+++ b/net/queue.go
@@ -41,4 +41,7 @@ type Queue interface {
 	Enque(data []byte) error
 	Deque() (data []byte, err error)
 	Empty() bool
+	Has(hash []byte) bool
+	Size() int
 }
+

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -60,7 +60,7 @@ func rand_bytes(length int) []byte {
 }
 
 func TestEnqueThenDeque(t *testing.T) {
-	q := NewQueue()
+	q := NewQueue(true)
 	l := make([][]byte, 0, 25)
 	for i := 0; i < rand.Intn(25)+10; i++ {
 		item := rand_bytes(rand.Intn(32) + 2)


### PR DESCRIPTION
Added three new commands HAS, SIZE and USE. Has allows you to check if a given item is in the queue by sending the sha256sum of the item. Size reports the number of items current enqueued. It now also supports a queueing mode which does not allow duplicates in the queue. Use, allows the client to select an different queue to use.
##### HAS XXXXXXXXXXXXXXXXXXXXXXXXXXX

HAS checks for the existence of an item. It doesn't send the item but
rather the base64 encoded sha265sum. Example for producing this (in
Python for simplicity)

```
>>> import hashlib
>>> hashlib.sha256('item').digest().encode('base64').strip()
'SjPqzV+mXysuKHHNExKGtTxBWxMWZtcRc7tuP+WTYbM='
```

The client would send

```
HAS SjPqzV+mXysuKHHNExKGtTxBWxMWZtcRc7tuP+WTYbM=
```

The server would reponse either

```
TRUE
```

or

```
FALSE
```
##### SIZE

The server response with the size of the queue encoded as a base10
ascii number. eg.

```
SIZE 9231
```

For a queue that is 9,231 items long.
##### USE name

Use the named queue. You never have to issue this command. If you do not
you will automatically be using a queue named "default". If the queue does
not this command will create one. The server should respond:

```
 OK
```

name should have no spaces and should be utf8.
